### PR TITLE
Add script for deleting connection as referenced in the docs

### DIFF
--- a/src/embeddable.com/scripts/connection-delete.cjs
+++ b/src/embeddable.com/scripts/connection-delete.cjs
@@ -1,0 +1,22 @@
+const apiKey = '...';
+const connectionName = 'my-db';
+
+const BASE_URL = 'https://api.us.embeddable.com'; // US
+// const BASE_URL = 'https://api.eu.embeddable.com'; // EU
+
+async function run() {
+  const resp = await fetch(`${BASE_URL}/api/v1/connections/${connectionName}`, {
+    method: 'DELETE', // PUT = UPDATE
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}` /* keep your API Key secure */,
+    },
+  });
+
+  console.log(`${resp.status} ${resp.statusText}`);
+  const json = await resp.json();
+  console.log(json);
+}
+
+run();


### PR DESCRIPTION
Our documentation mentions a delete connection script, but one does not actually exist. This rectifies that issue.